### PR TITLE
MVS CPLD: don't go back to menu on RESET

### DIFF
--- a/CPLD/MVS/PROG_CP1/rtl/cp1_top.v
+++ b/CPLD/MVS/PROG_CP1/rtl/cp1_top.v
@@ -44,7 +44,7 @@ module cp1_top(
 	reg [2:0] BANKS;
 	reg [8:0] IX;
 
-	reg [7:0] GSEL;
+	reg [7:0] GSEL = 8'b00000000;
 
 	assign ICON = {1'bz, GSEL[7:3], 1'bz, GSEL[2:0]};
 
@@ -71,7 +71,6 @@ module cp1_top(
 		if (!nRESET)
 		begin
 			P_BANK <= 3'd0;
-			GSEL   <= 8'd0;
 		end
 		else
 		begin


### PR DESCRIPTION
There are a couple games on MVS (ie: mslug2) that have a check to try and verify the MVS motherboard is an original one.  This check involves writing some data to backup ram, and forcing the game to watchdog.  If the watchdog doesn't trigger a reboot, the game will display a message about using original MVS hardware.

A watchdog triggers a full reboot of the motherboard including a low/high on the RESET line.  This was causing the MVS 161in1 cart to go back to the menu if you tried to load one of these games.