### PR TITLE
Update menu name for Flip Shot

### DIFF
--- a/Compiler/Games/flipshot/menu
+++ b/Compiler/Games/flipshot/menu
@@ -1,1 +1,1 @@
-Battle Flip Shot
+Flip Shot


### PR DESCRIPTION
The original name on the label is "Flip Shot". 
https://www.mvs-scans.com/index.php/Flip_Shot